### PR TITLE
fixed nomod scores assuming fc (caused by incorrect mods parameter)

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -25,11 +25,16 @@ var tasks = make(chan oppaiTask, 500)
 // Worker is a goroutine that calculates PP.
 func Worker() {
 	for task := range tasks {
+		strmods := strings.TrimSpace(task.Mods.String())
+		if strmods == "" {
+			strmods = "nomod"
+		}
+
 		cmd := exec.Command(
 			"./oppai",
 			task.FilePath,
 			strconv.FormatFloat(task.Accuracy, 'f', -1, 64)+"%",
-			"+"+strings.ToLower(task.Mods.String()),
+			"+"+strings.ToLower(strmods),
 			strconv.Itoa(task.MaxCombo)+"x",
 			strconv.Itoa(task.Misses)+"m",
 		)


### PR DESCRIPTION
it was passing just the mods prefix for nomod, but it should either be omitted entirely or just +nomod
